### PR TITLE
Split up docker-compose into extended services

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+FODY_SRC=../intelmq-fody
+FODY_BACKEND_SRC=../intelmq-fody-backend

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+fody-backend/conf/fody-session.sqlite

--- a/Dockerfile.fody
+++ b/Dockerfile.fody
@@ -1,5 +1,9 @@
 FROM ubuntu:20.04
 
+ARG REVISION
+
+ENV REVISION ${REVISION}
+
 RUN apt-get update && apt-get install -y curl gnupg
 RUN echo "deb https://deb.nodesource.com/node_14.x focal main" >/etc/apt/sources.list.d/nodesource.list
 
@@ -18,6 +22,8 @@ WORKDIR /opt/src/
 RUN git clone https://github.com/Intevation/intelmq-fody.git
 
 WORKDIR /opt/src/intelmq-fody
+
+RUN git checkout $REVISION
 
 COPY fody/index.js /opt/src/intelmq-fody/config/index.js
 

--- a/Dockerfile.fody-backend
+++ b/Dockerfile.fody-backend
@@ -1,5 +1,9 @@
 FROM ubuntu:20.04
 
+ARG REVISION
+
+ENV REVISION ${REVISION}
+
 # Install dependencies and stuff
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y git python3-pip python3-psycopg2 python3-dateutil swig libgpgme-dev sqlite3
 
@@ -16,6 +20,8 @@ RUN git clone https://github.com/Intevation/intelmq-mailgen.git
 
 # Clone the fody backend
 RUN git clone https://github.com/Intevation/intelmq-fody-backend.git
+
+RUN cd intelmq-fody-backend && git checkout $REVISION
 
 ENV FODY_SESSION_CONFIG /etc/intelmq/fody-session.conf
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ The ```--no-cache``` flags prevents docker from using old intermediate images.
 Creates and starts the containers.
 Add ```-d``` to run in background.
 
-The Fody (frontend) container starts with yarn in development mode. Changes in the code automaccaly trigger a refresh in the browser. Only if dependensies change a login to the container is required to restart the yarn dev server:
+The Fody (frontend) container starts with yarn in development mode. Changes in the code automaccaly trigger a refresh in the browser. Only if dependencies change a login to the container is required to restart the yarn dev server:
+
+```
+docker exec -ti intelmq-fody-spa /bin/bash
+    $ kill `pidof node`
+    $ yarn
+    $ yarn run dev 2>&1 &
+```
+
+Do not kill the ```tail``` process. It keeps the container alive when killing node processes.
 
 ### General
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,55 @@ enviroment for intelmq and fody.
 
 ### FOR DEVELOPMENT ONLY! CONTAINS INSECURE PLAINTEXT PASSWORDS!
 
+## Contents
+
+- [Introduction](#Introduction)
+- [Usage](#Usage)
+    - [Scenario 1](#scenario-1-default)
+    - [Scenario 2](#scenario-2)
+    - [General](#General)
+## Introduction
+
+The docker (-compose) environment can be used for four differnet scenarios:
+
+1. Test-Setup with services build from source with a given revision (default is master)
+1. Development-Setup with mounted source code for easy editing
+1. Test-Setup with services build from package (file system)
+1. Test-Setup with services build from package (repository)
+
 ## Usage
 
-### Build and startup
-```docker-compose up --build```
+On the first startup, the two containers intelmq-contactdb and intelmq-fody-backend seem to hang. The reason is that the data import for the contactdb takes some time and the fody backend waits forthe import to finish.
 
-Creates the Images and starts the containers.
+### Scenario 1 (default)
+
+```docker-compose build --no-cache```
+
+Creates the Images using the dockerfiles.
+The ```--no-cache``` flags prevents docker from using old intermediate images.
+
+``` docker-compose up```
+
+Creates and starts the containers.
 Add ```-d``` to run in background.
 
-```docker-compose start```
+### Scenario 2
 
-Starts already existing containers
+Using the docker containers for development requires a local checkout of fody and fody-backend. Mounting them as volume is specified in the ```docker-compose.dev.yml``` and the path to the source code is defined in the ```.env``` file.
+
+```docker-compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache```
+
+Creates the Images using the dockerfiles.
+The ```--no-cache``` flags prevents docker from using old intermediate images.
+
+``` docker-compose -f docker-compose.yml -f docker-compose.dev.yml up```
+
+Creates and starts the containers.
+Add ```-d``` to run in background.
+
+The Fody (frontend) container starts with yarn in development mode. Changes in the code automaccaly trigger a refresh in the browser. Only if dependensies change a login to the container is required to restart the yarn dev server:
+
+### General
 
 ```docker-compose down```
 
@@ -25,20 +63,31 @@ Stops and removes the containers.
 
 Stops the containers.
 
-### Using the containers
+```docker-compose images```
+
+Lists all images used for the services.
+
+``` docker rmi intelmq-base intelmq-contactdb intelmq-eventdb intelmq-fody-backend intelmq-fody-spa```
+
+Removes the images.
+
+### The containers
+
+```docker-compose start```
+
+Starts already existing containers
+
+
+### Using the applications
 
 The IntelMQ-Manager is listening on port 1337 and the Fody frontend is available on port 1380 per default.
 
-IntelMQ-Manager needs credentials to login.
-The default user is ```admin``` with the password ```secret```. For more users login to the docker container named ``` intelmq-base``` and follow the intstructions in the [documentation](https://intelmq.readthedocs.io/en/maintenance/user/intelmq-api.html#id6)
+IntelMQ-Manager and Fody need credentials to login.
+The default user is ```admin``` with the password ```secret```. For more users login to the docker container named ``` intelmq-base``` or ```intelmq-fody-backend``` and follow the intstructions in the [documentation](https://intelmq. readthedocs.io/en/maintenance/user/intelmq-api.html#id6) for IntelMQ-Manager and [TODO]() for Fody.
 ## ContactDB
 
 Using the contactdb depends on data that can change daily. The directory name contains the current date so rebuilding the container with an image on an other date than the image was build leaves the databse empty.
 
-Rebuild the image to get an up to date database.
+Rebuild the image with no cache to get an up to date database.
 
 Starting the setup with a fresh data import for the contactdb will take some time so please be patient.
-
-## TODO
-
-Documentation how to mount development folders and refresh containers.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+    fody-backend:
+        volumes: 
+            - ${FODY_BACKEND_SRC}:/opt/intelmq-fody-backend
+    fody:
+        volumes: 
+            - ${FODY_SRC}:/opt/src/intelmq-fody

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+    fody-backend:
+        # volumes: 
+        #     - ${FODY_BACKEND_SRC}:/opt/intelmq-fody-backend
+        build:
+            args:
+                REVISION: "master" 
+    fody:
+        # volumes: 
+        #     - ${FODY_SRC}:/opt/src/intelmq-fody
+        build:
+            args:
+                REVISION: "master" 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,6 @@ services:
         restart: always
         ports:
             - 1380:8080
-        # volumes:
-        #   - ../intelmq-fody:/opt/src/intelmq-fody
         depends_on:
             - fody-backend
         networks:

--- a/fody/startup-spa.sh
+++ b/fody/startup-spa.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
 echo $PWD
 yarn 2>&1
-yarn run dev 2>&1
+yarn run dev 2>&1 &
+tail -F anything


### PR DESCRIPTION
docker-compse is now implemented to have extended services.

The services are defined in docker-compose.*.yml files. Currently there are two versions, the default and a dev version.