### PR TITLE
Small improvements to package building process

### DIFF
--- a/pkg/build-packages.sh
+++ b/pkg/build-packages.sh
@@ -19,6 +19,9 @@
 # release packages can be build (in contrast to development snapshot
 # build).
 
+# Abort on errors:
+set -eu -o pipefail
+
 DEFAULT_PKGS=(
   intelmq-certbund-contact
   intelmq-fody

--- a/pkg/intelmq-base/Dockerfile
+++ b/pkg/intelmq-base/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:focal
 
 LABEL authors="Gernot Schulz <gernot@intevation.de>,Sascha Wilde <wilde@intevation.de>"
 
-RUN apt-get update && apt-get install -y vim-tiny
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update && apt-get install -y vim-tiny
 
 ADD https://hg.intevation.de/adminton/raw-file/tip/logbuch-tools/logbuch-installer /root/
 RUN LOGBUCH_BATCHMODE=yes \


### PR DESCRIPTION
- pkg/build-packages.sh: abort on errors
prevents overseeing errors hiding the root-causes of following fails
- Dockerfile intelmq-base: set non-interactive frontend for apt call