### PR TITLE
Fix some build issues

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,6 +33,7 @@ services:
         build:
             args:
                 REVISION: $SOURCE_WEBINPUT_CSV_BACKEND_REVISION
+                INTELMQ_REVISION: $SOURCE_INTELMQ_REVISION
     webinput-csv:
         # volumes:
         #     - $WEBINPUT_CSV_SRC:/opt/src/intelmq-webinput-csv

--- a/intelmq/Dockerfile
+++ b/intelmq/Dockerfile
@@ -31,6 +31,7 @@ RUN useradd -d /opt/intelmq -U -s /bin/bash intelmq \
 
 # Checkout the intelmq master as the stable branch
 # and install.
+RUN git config --global --add safe.directory /opt/intelmq
 RUN git checkout $INTELMQ_REVISION && pip3 install -e .
 
 # Run intelmqsetup to get a complete enviroment
@@ -47,9 +48,6 @@ RUN git checkout $INTELMQ_API_REVISION
 RUN pip3 install -e .
 
 RUN python3 contrib/initesqlite.py
-
-COPY intelmq/api-config/api-config.json /usr/local/lib/python3.8/dist-packages/etc/intelmq/api-config.json
-ENV INTELMQ_API_CONFIG /usr/local/lib/python3.8/dist-packages/etc/intelmq/api-config.json
 
 WORKDIR /opt
 
@@ -68,6 +66,10 @@ RUN cp -R html/* /var/www/html
 COPY intelmq/apache-config/intelmq.conf /etc/apache2/sites-available/000-default.conf
 
 RUN a2enmod proxy proxy_http
+
+# Needs to be done after the installation of intelmq-manager, as intelmq-manager installs intelmq-api again
+COPY intelmq/api-config/api-config.json /usr/local/lib/python3.8/dist-packages/etc/intelmq/api-config.json
+ENV INTELMQ_API_CONFIG /usr/local/lib/python3.8/dist-packages/etc/intelmq/api-config.json
 
 WORKDIR /opt
 
@@ -107,8 +109,6 @@ RUN pip3 install -e .
 #RUN chgrp www-data /opt/intelmq/etc/*.conf /opt/intelmq/etc/manager/positions.conf
 
 #RUN chmod g+w /opt/intelmq/etc/*.conf /opt/intelmq/etc/manager/positions.conf
-
-RUN sqlite3 /var/lib/dbconfig-common/sqlite3/intelmq-api/intelmqapi
 
 RUN intelmq-api-adduser --user admin --password secret
 

--- a/webinput-csv-backend/Dockerfile
+++ b/webinput-csv-backend/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:20.04
 
 ARG REVISION
+ARG INTELMQ_REVISION
 
 ENV REVISION ${REVISION}
+ENV INTELMQ_REVISION ${INTELMQ_REVISION}
 
 # Install dependencies and stuff
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y git python3-pip sqlite3
@@ -10,7 +12,7 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y git py
 WORKDIR /opt
 
 # Install dependencies
-RUN pip3 install intelmq==2.3.1 hug
+RUN pip3 install intelmq==$INTELMQ_REVISION hug
 
 RUN git clone https://github.com/Intevation/intelmq-webinput-csv.git
 


### PR DESCRIPTION
fix building the intelmq docker image:
- /opt/intelmq/ needs to be added to the git safe directories
- writing the api config makes only sense after the (second)
  installation of intelmq-api, otherwise it is just overwritten
- remove unnecessary sqlite3 command

webinput-csv-backend: use intelmq version from env:
use the configured intelmq version also in intelmq-webinput-csv-backend